### PR TITLE
[재영] 2개 이하로 다른 비트, 멀리뛰기

### DIFF
--- a/황재영/2개 이하로 다른 비트.md
+++ b/황재영/2개 이하로 다른 비트.md
@@ -1,0 +1,24 @@
+```kt
+class Solution {
+  fun solution(numbers: LongArray): LongArray {
+      return numbers.map { findMinimumLowerThan2Bit(it) }.toLongArray();
+  }
+
+  fun findMinimumLowerThan2Bit(num: Long): Long {
+      val bit = num.toString(2);
+      val last0Index = bit.lastIndexOf('0');
+
+      if (last0Index == bit.lastIndex) {
+          return num + 1;
+      }
+
+      if (last0Index < 0) {
+          return num + (1L shl bit.length) / 2;
+      }
+
+      val plusValue = 1L shl (bit.lastIndex - last0Index - 1);
+
+      return num + (if (plusValue > 0) plusValue else 0);
+  }
+}
+```

--- a/황재영/멀리뛰기.md
+++ b/황재영/멀리뛰기.md
@@ -1,0 +1,18 @@
+```kt
+class Solution {
+  fun solution(n: Int): Long {
+      val dp = LongArray(2001)
+
+      dp.forEachIndexed { index, _ ->
+          if (index <= 2) {
+              dp[index] = index.toLong()
+              return@forEachIndexed
+          }
+
+          dp[index] = (dp[index - 1] + dp[index - 2]) % 1234567
+      }
+
+      return dp[n]
+  }
+}
+```


### PR DESCRIPTION
## ⚠️ 연결된 이슈를 적어주세요!
<!-- #11 -->

#52 

## 🌟 문제의 제목과 출처를 작성해주세요.
<!-- ex: [N-Queen](https://프로그래머스.com) -->

- [2개 이하로 다른 비트](https://school.programmers.co.kr/learn/courses/30/lessons/77885)
- [멀리뛰기](https://school.programmers.co.kr/learn/courses/30/lessons/12914)

## 🕰 문제를 푸는 데 걸린 시간은 어떠했나요?

- 2개 이하로 다른 비트: 1시간 30분...?
- 멀리뛰기: 2분

## ✨ 풀이 과정에 대해서 설명해봅시다.

## 💥 문제의 핵심 알고리즘

- 그리디
- DP

## 🔥 상세 풀이 과정

## 💎 배운 점, 그리고 제대로 숙지하지 못했던 점

### 🌙 배운 점

### 💧 제대로 숙지하지 못했던 점

그리디로 풀지 않고 비트마스킹으로 풀었는데, 결국 시간초과가 나서 딜레이가 많이 됐습니다.
원인을 찾아보니, 10^15가 되는 수까지 있기 때문에 증분할 시 최악의 경우 약 O(10^15)만큼 시간이 날 수 있음을 확인했습니다.
따라서 그리디로 풀었고, 이에 관해서 세게 반성하게 되었습니다...
